### PR TITLE
chore(git): no-binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ local/
 
 # Build artifacts
 bin/
-./mcp-ripestat
+/mcp-ripestat


### PR DESCRIPTION
Remove mcp binary and remove it from history. It shouldn't be there in the first place.