### PR TITLE
chore(flags): help

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ By default, the server runs on port `8080`. You can change this by setting the
 ./mcp-ripestat --port=8888 --debug
 ```
 
+### Flags
+
+The following command-line flags are available:
+
+- `--port`: Sets the port for the server to listen on (default: `8080`).
+- `--debug`: Enables debug logging.
+- `--help`: Prints all possible flags.
+
 ### MCP Client Configuration
 
 To integrate the server with MCP client, add the following configuration to your

--- a/cmd/mcp-ripestat/main.go
+++ b/cmd/mcp-ripestat/main.go
@@ -20,7 +20,20 @@ import (
 func main() {
 	port := flag.String("port", "8080", "Port for the server to listen on")
 	debug := flag.Bool("debug", false, "Enable debug logging")
+	help := flag.Bool("help", false, "Print all possible flags")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [options]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		flag.PrintDefaults()
+	}
+
 	flag.Parse()
+
+	if *help {
+		flag.Usage()
+		os.Exit(0)
+	}
 
 	logLevel := slog.LevelInfo
 	if *debug {


### PR DESCRIPTION
This PR adds a --help flag to the command line interface. This flag prints all possible flags and their descriptions. The README has been updated to reflect this change.