### PR TITLE
feat(routing-history): implement RIPEstat routing-history endpoint

### DIFF
--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -1,0 +1,68 @@
+# 🍳 Next-level investigations
+
+Here’s a grab-bag of “next-level” questions you can throw at the
+`mcp-ripestat` server. Feel free to contribute your own with a PR.
+
+I’ve grouped them by investigation style and shown the workflow call(s) that will be issued under the hood for each prompt.
+
+## BGP & RPKI threat hunting
+
+| 🍳 Prompt | 🔧 Workflow |
+| “For AS 20940 (Akamai) list every prefix it originated in the last 48 h that is RPKI-invalid and tell me which RIS collectors first saw the leak.” | • announced-prefixes returns the live prefix set for AS 20940 ￼ • Each prefix/ASN pair is piped into rpki-validation for status=invalid_asn/invalid_length ￼ • bgp-updates filtered to those prefixes + “A”nnouncements surfaces the first RRC/time seen |￼
+| “Show me any /24s in 185.0.0.0/14 that went from ‘unknown’ to ‘valid’ RPKI state in the last week.” | • Sliding-window diff of rpki-history (counts of VRPs) • Compare status snapshots, emit changed prefixes |
+
+**Why it’s fancy**: You get instant leak hijack detection without writing BGP
+parsers, plus provenance (which collector saw it first).
+
+## Real-time outage triage
+
+| 🍳 Prompt | 🔧 Workflow |
+| “Is there a routing black-hole around IP 203.0.113.45 right now? Show which collectors still see a path and the last AS hop.” | looking-glass gives per-RRC visibility and full AS-PATHs ￼; the LLM groups peers by last-updated timestamp and highlights gaps. |
+| “Compare the upstream set for AS 6453 today vs. 72 hours ago and highlight new or missing peers.” Diff two asn-neighbours snapshots; render a before/after table.
+
+Why it’s fancy: You’re effectively turning the RIS network into a distributed “ping” without touching a router.
+
+⸻
+
+## Abuse & takedown workflows (cross-dataset)
+
+| 🍳 Prompt | 🔧 Workflow |
+“Give me the abuse-mailbox for every prefix that belongs to the IPs hosting examplephish[.]com and tell me which of those IPs expose RDP.” 1. mcp-censys → lookup_domain to enumerate host IPs & ports ￼ 2. abuse-contact-finder for each IP/prefix ￼ 3. The LLM correlates and outputs a ready-to-mail list.
+“Find all Shodan-indexed hosts inside AS 9808 that run OpenSSH < 8.2 and whose RPKI status is invalid.” 1. mcp-shodan → search query org:"AS9808" product:"OpenSSH" version:<8.2 ￼ 2. For each hit, call rpki-validation to check prefix/ASN combo; filter status != valid.
+
+⸻
+
+## Geo-policy & compliance checks
+
+| 🍳 Prompt | 🔧 Workflow |
+“List every routed ASN registered in 🇷🇺 Russia and the countries where their prefixes are actually being announced from.” country-asns (registered vs routed) + prefix-overview for geolocation per prefix ￼
+“Which ASNs that appear in OFAC-sanctioned countries are transiting traffic through EU IXPs?” Combine previous query with public IX-prefix lists (or IX-API via another MCP server) and looking-glass visibility.
+
+⸻
+
+## Historical forensics
+
+| 🍳 Prompt | 🔧 Workflow |
+“When did AS 212238 first start announcing 2a0c:9a40::/29 and what other ASNs announced it beforehand?” routing-history for that prefix; LLM finds earliest time & origin-change events.
+“Plot the VRP count for 8.8.8.0/24 over the past year and annotate dips.” rpki-history time-series; LLM (or a python_user_visible plot) highlights anomalies.
+
+## Putting it all together in one sentence
+
+• “Over the last 24 h, which prefixes newly originated by AS 61138 are invalid in RPKI, have at least one open Telnet port according to Shodan, and lack an abuse mailbox?”
+• “Give me a timeline of BGP withdrawals for 2400:cb00::/32 during Cloudflare’s Oct-2024 outage and overlay it with the count of probes failing HTTPS from RIPE Atlas.”
+
+The LLM will federate: 1. RIPEstat (mcp-ripestat) for route, RPKI, Whois, visibility. 2. Shodan (mcp-shodan) for service & vuln intel. 3. Censys (mcp-censys) or any other MCP OSINT source for certificates/DNS. 4. Optionally, an Atlas or Pingdom MCP server for active-measurements.
+
+⸻
+
+## Tip: Hint the tool names
+
+If a client supports explicit tool selection, prefix can be specified
+to the prompt:
+
+```sh
+@ripestat announced_prefixes AS61138 starttime=2025-06-24T00:00Z
+```
+
+…but 90 % of the time you can stay high-level and just say
+“Show/Get me...” — the LLM will decide which function to invoke.

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -28,9 +28,9 @@ RIPEstat API endpoint(s) it utilizes.
 | 14     | `sprint-14` | TBD     | MCP Authorization          | N/A                          | Planned   |
 | 15     | `sprint-15` | TBD     | MCP Streaming Protocol     | N/A                          | Planned   |
 | 16     | `sprint-16` | TBD     | BGPlay                     | `bgplay`                     | Planned   |
-| 17     | sprint-17`  | TBD     | Routing History            | `routing-history`            | Planned   |
-| 18     | sprint-18`  | TBD     | Country ASNs               | `country-asns-history`       | Planned   |
-| 19     | sprint-19`  | TBD     | Prefix Overview            | `prefix-overview`            | Planned   |
-| 20     | sprint-20`  | TBD     | RPKI History               | `rpki-history`               | Planned   |
-| 21     | sprint-21`  | TBD     | BGP Updates                | `bgp-updates`                | Planned   |
-| 21     | sprint-22`  | TBD     | Prefix Routing Consistency | `prefix-routing-consistency` | Planned   |
+| 17     | `sprint-17` | TBD     | Routing History            | `routing-history`            | Completed |
+| 18     | `sprint-18` | TBD     | Country ASNs               | `country-asns-history`       | Planned   |
+| 19     | `sprint-19` | TBD     | Prefix Overview            | `prefix-overview`            | Planned   |
+| 20     | `sprint-20` | TBD     | RPKI History               | `rpki-history`               | Planned   |
+| 21     | `sprint-21` | TBD     | BGP Updates                | `bgp-updates`                | Planned   |
+| 21     | `sprint-22` | TBD     | Prefix Routing Consistency | `prefix-routing-consistency` | Planned   |

--- a/cmd/mcp-ripestat/main.go
+++ b/cmd/mcp-ripestat/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/taihen/mcp-ripestat/internal/ripestat/asoverview"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/lookingglass"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/networkinfo"
+	"github.com/taihen/mcp-ripestat/internal/ripestat/routinghistory"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/routingstatus"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/rpkivalidation"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/whatsmyip"
@@ -88,6 +89,7 @@ func run(ctx context.Context, port string, disableWhatsMyIP bool) error {
 	mux.HandleFunc("/as-overview", asOverviewHandler)
 	mux.HandleFunc("/announced-prefixes", announcedPrefixesHandler)
 	mux.HandleFunc("/routing-status", routingStatusHandler)
+	mux.HandleFunc("/routing-history", routingHistoryHandler)
 	mux.HandleFunc("/whois", whoisHandler)
 	mux.HandleFunc("/abuse-contact-finder", abuseContactFinderHandler)
 	mux.HandleFunc("/rpki-validation", rpkiValidationHandler)
@@ -247,6 +249,21 @@ func manifestHandler(w http.ResponseWriter, r *http.Request, disableWhatsMyIP bo
 			},
 		},
 		{
+			Name:        "getRoutingHistory",
+			Description: "Get routing history information for an IP address, prefix, or ASN.",
+			Parameters: []Parameter{
+				{
+					Name:        "resource",
+					Type:        "string",
+					Required:    true,
+					Description: "The IP address, prefix, or ASN to query for routing history.",
+				},
+			},
+			Returns: Return{
+				Type: "object",
+			},
+		},
+		{
 			Name:        "getWhois",
 			Description: "Get whois information for an IP address, prefix, or ASN.",
 			Parameters: []Parameter{
@@ -389,6 +406,12 @@ func announcedPrefixesHandler(w http.ResponseWriter, r *http.Request) {
 func routingStatusHandler(w http.ResponseWriter, r *http.Request) {
 	handleRIPEstatRequest(w, r, "routing-status", func(ctx context.Context, resource string) (interface{}, error) {
 		return routingstatus.GetRoutingStatus(ctx, resource)
+	})
+}
+
+func routingHistoryHandler(w http.ResponseWriter, r *http.Request) {
+	handleRIPEstatRequest(w, r, "routing-history", func(ctx context.Context, resource string) (interface{}, error) {
+		return routinghistory.GetRoutingHistory(ctx, resource)
 	})
 }
 

--- a/e2e/routinghistory_test.go
+++ b/e2e/routinghistory_test.go
@@ -1,0 +1,76 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taihen/mcp-ripestat/internal/ripestat/client"
+	"github.com/taihen/mcp-ripestat/internal/ripestat/routinghistory"
+)
+
+func TestRoutingHistoryE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+
+	c := client.DefaultClient()
+	routingHistoryClient := routinghistory.New(c)
+
+	tests := []struct {
+		name     string
+		resource string
+		wantErr  bool
+	}{
+		{
+			name:     "RIPE NCC ASN",
+			resource: "AS3333",
+			wantErr:  false,
+		},
+		{
+			name:     "RIPE NCC prefix",
+			resource: "193.0.0.0/21",
+			wantErr:  false,
+		},
+		{
+			name:     "Google DNS IP",
+			resource: "8.8.8.8",
+			wantErr:  false,
+		},
+		{
+			name:     "Cloudflare ASN",
+			resource: "AS13335",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := routingHistoryClient.Get(context.Background(), tt.resource)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Get() error = nil, wantErr %v", tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if result == nil {
+				t.Error("Get() result is nil, want non-nil")
+				return
+			}
+
+			if result.Data.Resource == "" {
+				t.Error("Get() result.Data.Resource is empty, want non-empty")
+			}
+
+			if len(result.Data.ByOrigin) == 0 {
+				t.Log("Get() result.Data.ByOrigin is empty - this may be normal for some resources")
+			}
+		})
+	}
+}

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -177,6 +177,20 @@ func CreateToolsList() *ToolsListResult {
 			},
 		},
 		{
+			Name:        "getRoutingHistory",
+			Description: "Get routing history information for an IP address, prefix, or ASN.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"resource": map[string]interface{}{
+						"type":        "string",
+						"description": "The IP address, prefix, or ASN to query for routing history.",
+					},
+				},
+				"required": []string{"resource"},
+			},
+		},
+		{
 			Name:        "getWhois",
 			Description: "Get whois information for an IP address, prefix, or ASN.",
 			InputSchema: map[string]interface{}{

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/taihen/mcp-ripestat/internal/ripestat/asoverview"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/lookingglass"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/networkinfo"
+	"github.com/taihen/mcp-ripestat/internal/ripestat/routinghistory"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/routingstatus"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/rpkivalidation"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/whatsmyip"
@@ -206,6 +207,8 @@ func (s *Server) executeToolCall(ctx context.Context, params *CallToolParams) (*
 		return s.callAnnouncedPrefixes(ctx, args)
 	case "getRoutingStatus":
 		return s.callRoutingStatus(ctx, args)
+	case "getRoutingHistory":
+		return s.callRoutingHistory(ctx, args)
 	case "getWhois":
 		return s.callWhois(ctx, args)
 	case "getAbuseContactFinder":
@@ -277,6 +280,20 @@ func (s *Server) callRoutingStatus(ctx context.Context, args map[string]interfac
 	}
 
 	result, err := routingstatus.GetRoutingStatus(ctx, resource)
+	if err != nil {
+		return CreateToolResult(fmt.Sprintf("Error: %v", err), true), nil
+	}
+
+	return CreateToolResultFromJSON(result), nil
+}
+
+func (s *Server) callRoutingHistory(ctx context.Context, args map[string]interface{}) (*ToolResult, error) {
+	resource, ok := args["resource"].(string)
+	if !ok {
+		return nil, fmt.Errorf("resource parameter is required")
+	}
+
+	result, err := routinghistory.GetRoutingHistory(ctx, resource)
 	if err != nil {
 		return CreateToolResult(fmt.Sprintf("Error: %v", err), true), nil
 	}

--- a/internal/ripestat/routinghistory/routinghistory.go
+++ b/internal/ripestat/routinghistory/routinghistory.go
@@ -1,0 +1,50 @@
+package routinghistory
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/taihen/mcp-ripestat/internal/ripestat/client"
+	"github.com/taihen/mcp-ripestat/internal/ripestat/errors"
+)
+
+// Client provides access to the RIPEstat routing-history API.
+type Client struct {
+	client *client.Client
+}
+
+// New creates a new routing-history client.
+func New(c *client.Client) *Client {
+	return &Client{client: c}
+}
+
+// Get retrieves routing history information for the specified resource.
+// The resource can be an IP address, IP prefix, or ASN.
+func (c *Client) Get(ctx context.Context, resource string) (*Response, error) {
+	if resource == "" {
+		return nil, errors.ErrInvalidParameter.WithError(fmt.Errorf("resource parameter is required"))
+	}
+
+	params := url.Values{}
+	params.Set("resource", resource)
+
+	endpoint := "/data/routing-history/data.json"
+
+	var response Response
+	if err := c.client.GetJSON(ctx, endpoint, params, &response); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// DefaultClient returns a new Client with default settings.
+func DefaultClient() *Client {
+	return New(client.DefaultClient())
+}
+
+// GetRoutingHistory is a convenience function that uses the default client to get routing history information.
+func GetRoutingHistory(ctx context.Context, resource string) (*Response, error) {
+	return DefaultClient().Get(ctx, resource)
+}

--- a/internal/ripestat/routinghistory/routinghistory_exported_test.go
+++ b/internal/ripestat/routinghistory/routinghistory_exported_test.go
@@ -1,0 +1,107 @@
+package routinghistory_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taihen/mcp-ripestat/internal/ripestat/client"
+	"github.com/taihen/mcp-ripestat/internal/ripestat/routinghistory"
+)
+
+func TestRoutingHistoryIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	c := client.DefaultClient()
+	routingHistoryClient := routinghistory.New(c)
+
+	tests := []struct {
+		name     string
+		resource string
+		wantErr  bool
+	}{
+		{
+			name:     "valid ASN",
+			resource: "AS3333",
+			wantErr:  false,
+		},
+		{
+			name:     "valid IP prefix",
+			resource: "193.0.0.0/21",
+			wantErr:  false,
+		},
+		{
+			name:     "valid IP address",
+			resource: "8.8.8.8",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := routingHistoryClient.Get(context.Background(), tt.resource)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Get() error = nil, wantErr %v", tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if result == nil {
+				t.Error("Get() result is nil, want non-nil")
+				return
+			}
+
+			if result.Data.Resource == "" {
+				t.Error("Get() result.Data.Resource is empty, want non-empty")
+			}
+		})
+	}
+}
+
+func TestGetRoutingHistoryFunction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tests := []struct {
+		name     string
+		resource string
+		wantErr  bool
+	}{
+		{
+			name:     "valid ASN",
+			resource: "AS3333",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := routinghistory.GetRoutingHistory(context.Background(), tt.resource)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("GetRoutingHistory() error = nil, wantErr %v", tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("GetRoutingHistory() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if result == nil {
+				t.Error("GetRoutingHistory() result is nil, want non-nil")
+			}
+		})
+	}
+}

--- a/internal/ripestat/routinghistory/routinghistory_test.go
+++ b/internal/ripestat/routinghistory/routinghistory_test.go
@@ -1,0 +1,265 @@
+package routinghistory
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/taihen/mcp-ripestat/internal/ripestat/client"
+	ripestaterrors "github.com/taihen/mcp-ripestat/internal/ripestat/errors"
+)
+
+func TestClient_Get(t *testing.T) {
+	tests := []struct {
+		name         string
+		resource     string
+		mockResponse string
+		mockStatus   int
+		wantErr      bool
+		errType      *ripestaterrors.Error
+	}{
+		{
+			name:     "valid ASN",
+			resource: "AS3333",
+			mockResponse: `{
+				"status": "ok",
+				"status_code": 200,
+				"version": "1.0",
+				"data_call_name": "routing-history",
+				"data_call_status": "supported",
+				"cached": false,
+				"data": {
+					"by_origin": [
+						{
+							"origin": "3333",
+							"prefixes": [
+								{
+									"prefix": "193.0.0.0/21",
+									"timeline": [
+										{
+											"starttime": "2000-01-01T00:00:00",
+											"endtime": "2023-12-31T23:59:59",
+											"full_peers_seeing": 50
+										}
+									]
+								}
+							]
+						}
+					],
+					"resource": "AS3333"
+				}
+			}`,
+			mockStatus: http.StatusOK,
+			wantErr:    false,
+		},
+		{
+			name:     "valid IP prefix",
+			resource: "193.0.0.0/21",
+			mockResponse: `{
+				"status": "ok",
+				"status_code": 200,
+				"version": "1.0",
+				"data_call_name": "routing-history",
+				"data_call_status": "supported",
+				"cached": false,
+				"data": {
+					"by_origin": [
+						{
+							"origin": "3333",
+							"prefixes": [
+								{
+									"prefix": "193.0.0.0/21",
+									"timeline": [
+										{
+											"starttime": "2000-01-01T00:00:00",
+											"endtime": "2023-12-31T23:59:59",
+											"full_peers_seeing": 50
+										}
+									]
+								}
+							]
+						}
+					],
+					"resource": "193.0.0.0/21"
+				}
+			}`,
+			mockStatus: http.StatusOK,
+			wantErr:    false,
+		},
+		{
+			name:         "empty resource",
+			resource:     "",
+			mockResponse: "",
+			mockStatus:   http.StatusOK,
+			wantErr:      true,
+			errType:      ripestaterrors.ErrInvalidParameter,
+		},
+		{
+			name:         "server error",
+			resource:     "AS3333",
+			mockResponse: `{"error": "internal server error"}`,
+			mockStatus:   http.StatusInternalServerError,
+			wantErr:      true,
+			errType:      ripestaterrors.ErrServerError,
+		},
+		{
+			name:       "not found",
+			resource:   "invalid",
+			mockStatus: http.StatusNotFound,
+			wantErr:    true,
+			errType:    ripestaterrors.ErrNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockHTTPClient{
+				response: tt.mockResponse,
+				status:   tt.mockStatus,
+			}
+
+			c := client.New("https://stat.ripe.net", mockClient)
+			routingHistoryClient := New(c)
+
+			result, err := routingHistoryClient.Get(context.Background(), tt.resource)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Get() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+
+				if tt.errType != nil {
+					var targetErr *ripestaterrors.Error
+					if !errors.As(err, &targetErr) {
+						t.Errorf("Get() error type = %T, want *ripestaterrors.Error", err)
+						return
+					}
+					if targetErr.Message != tt.errType.Message {
+						t.Errorf("Get() error message = %v, want %v", targetErr.Message, tt.errType.Message)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if result == nil {
+				t.Error("Get() result is nil, want non-nil")
+				return
+			}
+
+			if len(result.Data.ByOrigin) == 0 {
+				t.Error("Get() result.Data.ByOrigin is empty, want non-empty")
+			}
+		})
+	}
+}
+
+func TestClient_Get_ParameterValidation(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		response: `{"status": "ok", "data": {"resource": "test"}}`,
+		status:   http.StatusOK,
+	}
+
+	c := client.New("https://stat.ripe.net", mockClient)
+	routingHistoryClient := New(c)
+
+	_, err := routingHistoryClient.Get(context.Background(), "AS3333")
+	if err != nil {
+		t.Errorf("Get() error = %v, want nil", err)
+	}
+
+	expectedURL := "https://stat.ripe.net/data/routing-history/data.json?resource=AS3333"
+	if mockClient.lastURL != expectedURL {
+		t.Errorf("Get() called URL = %s, want %s", mockClient.lastURL, expectedURL)
+	}
+}
+
+// MockHTTPClient implements the HTTPDoer interface for testing.
+type MockHTTPClient struct {
+	response string
+	status   int
+	lastURL  string
+}
+
+func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	m.lastURL = req.URL.String()
+
+	return &http.Response{
+		StatusCode: m.status,
+		Body:       &MockResponseBody{content: m.response},
+		Header:     make(http.Header),
+	}, nil
+}
+
+// MockResponseBody implements io.ReadCloser for testing.
+type MockResponseBody struct {
+	content string
+	pos     int
+}
+
+func (m *MockResponseBody) Read(p []byte) (n int, err error) {
+	if m.pos >= len(m.content) {
+		return 0, nil
+	}
+
+	n = copy(p, m.content[m.pos:])
+	m.pos += n
+	return n, nil
+}
+
+func (m *MockResponseBody) Close() error {
+	return nil
+}
+
+func TestDefaultClient(t *testing.T) {
+	client := DefaultClient()
+	if client == nil {
+		t.Error("DefaultClient() returned nil")
+		return
+	}
+	if client.client == nil {
+		t.Error("DefaultClient() returned client with nil internal client")
+	}
+}
+
+func TestGetRoutingHistory(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		wantErr  bool
+	}{
+		{
+			name:     "valid ASN",
+			resource: "AS3333",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetRoutingHistory(context.Background(), tt.resource)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("GetRoutingHistory() error = nil, wantErr %v", tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("GetRoutingHistory() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if result == nil {
+				t.Error("GetRoutingHistory() result is nil, want non-nil")
+			}
+		})
+	}
+}

--- a/internal/ripestat/routinghistory/types.go
+++ b/internal/ripestat/routinghistory/types.go
@@ -1,0 +1,36 @@
+package routinghistory
+
+import (
+	"github.com/taihen/mcp-ripestat/internal/ripestat/types"
+)
+
+// Response represents the top-level response from the RIPEstat routing-history endpoint.
+type Response struct {
+	types.BaseResponse
+	Data Data `json:"data"`
+}
+
+// Data represents the 'data' field in the response.
+type Data struct {
+	ByOrigin []OriginData `json:"by_origin"`
+	Resource string       `json:"resource"`
+}
+
+// OriginData represents routing data for a specific origin ASN.
+type OriginData struct {
+	Origin   string       `json:"origin"`
+	Prefixes []PrefixData `json:"prefixes"`
+}
+
+// PrefixData represents routing history for a specific prefix.
+type PrefixData struct {
+	Prefix   string          `json:"prefix"`
+	Timeline []TimelineEntry `json:"timeline"`
+}
+
+// TimelineEntry represents a single point in the routing history timeline.
+type TimelineEntry struct {
+	StartTime       string `json:"starttime"`
+	EndTime         string `json:"endtime"`
+	FullPeersSeeing int    `json:"full_peers_seeing"`
+}


### PR DESCRIPTION
Implement routing-history endpoint with REST and MCP support, including tests and documentation.