### PR TITLE
feat!: remove legacy REST API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For examples, investigation workflows, and usage patterns, see [PROMPTS](PROMPTS
 
 **Utility:**
 
-- What's My IP functionality with proxy header support for IP detection
+- Health check and warmup endpoints for monitoring and deployment
 
 ## Architectural Rationale
 
@@ -110,33 +110,21 @@ make build
 # Enable debug logging
 ./bin/mcp-ripestat --debug
 
-# Disable What's My IP endpoint (for shared environments this is undesirable)
-./bin/mcp-ripestat --disable-whats-my-ip
+# Run the server
+./bin/mcp-ripestat
 
 # Show help
 ./bin/mcp-ripestat --help
 ```
 
-### Proxy Support
+### Health Check Endpoints
 
-The What's My IP endpoint (`/whats-my-ip`) automatically detects the real client
-IP address when the server is behind a proxy or load balancer. It supports the
-following proxy headers:
+The server provides essential monitoring endpoints:
 
-- `X-Forwarded-For` - Standard proxy header and extended (GCP CloudRun)
-- `X-Real-IP` - Alternative proxy header
-- `CF-Connecting-IP` - Cloudflare-specific header
+- `/status` - Server status with uptime, version, and health information
+- `/warmup` - Warmup endpoint to prevent cold starts in containerized deployments
 
-When running behind a proxy or Cloudflare tunnel, the endpoint will
-automatically use these headers to determine the actual client IP address
-instead of the proxy's IP.
-
-### Shared Environment Configuration
-
-For shared environments, you might consider disabling the `What's My IP` endpoint
-using the `--disable-whats-my-ip` flag. If instance is behind a proxy or load
-balancer, you might see proxy IP address instead of the actual client IP. Check
-supported proxy headers above.
+These endpoints are essential for load balancers, monitoring systems, and deployment orchestration.
 
 ## MCP Protocol Support
 
@@ -150,14 +138,12 @@ JSON-RPC 2.0 transport. It provides two interfaces:
 - **Usage**: Compatible with Cursor IDE and other MCP clients
 - **Features**: Full MCP handshake, capability negotiation, tool calling
 
-### Legacy REST API (Deprecated)
+### Legacy REST API (Removed in v2)
 
 > [!FAIL]
-> This API is deprecated and will be removed in v2.
+> This API has been removed in v2. Use the MCP JSON-RPC endpoint instead.
 
-- **Endpoints**: Individual REST endpoints (e.g., `/network-info`)
-- **Protocol**: HTTP REST with query parameters
-- **Usage**: Direct API access and backward compatibility
+Legacy REST endpoints have been removed to keep the codebase compact and focused on the MCP protocol. All functionality previously available through REST endpoints is now accessible through the `/mcp` endpoint using the MCP protocol.
 
 ## MCP Client Configuration
 

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -37,4 +37,4 @@ implemented before Sprint 9 - depending on the needs of the project.
 | 20     | `sprint-20` | TBD     | RPKI History                  | `rpki-history`               | Planned   |
 | 21     | `sprint-21` | TBD     | BGP Updates                   | `bgp-updates`                | Planned   |
 | 22     | `sprint-22` | TBD     | Prefix Routing Consistency    | `prefix-routing-consistency` | Planned   |
-| 23     | `sprint-23` | TBD     | Removal of REST API Endpoints | N/A                          | Planned   |
+| 23     | `sprint-23` | v2.0.0  | Removal of REST API Endpoints | N/A                          | Completed |

--- a/cmd/mcp-ripestat/main.go
+++ b/cmd/mcp-ripestat/main.go
@@ -11,22 +11,10 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/taihen/mcp-ripestat/internal/mcp"
-	"github.com/taihen/mcp-ripestat/internal/ripestat/abusecontactfinder"
-	"github.com/taihen/mcp-ripestat/internal/ripestat/announcedprefixes"
-	"github.com/taihen/mcp-ripestat/internal/ripestat/asnneighbours"
-	"github.com/taihen/mcp-ripestat/internal/ripestat/asoverview"
-	"github.com/taihen/mcp-ripestat/internal/ripestat/lookingglass"
-	"github.com/taihen/mcp-ripestat/internal/ripestat/networkinfo"
-	"github.com/taihen/mcp-ripestat/internal/ripestat/routinghistory"
-	"github.com/taihen/mcp-ripestat/internal/ripestat/routingstatus"
-	"github.com/taihen/mcp-ripestat/internal/ripestat/rpkivalidation"
-	"github.com/taihen/mcp-ripestat/internal/ripestat/whatsmyip"
-	"github.com/taihen/mcp-ripestat/internal/ripestat/whois"
 )
 
 // version is set via -ldflags during build time.
@@ -35,7 +23,6 @@ var version = "dev"
 func main() {
 	port := flag.String("port", "8080", "Port for the server to listen on")
 	debug := flag.Bool("debug", false, "Enable debug logging")
-	disableWhatsMyIP := flag.Bool("disable-whats-my-ip", false, "Disable the whats-my-ip endpoint (useful for shared servers)")
 	showVersion := flag.Bool("version", false, "Show version information")
 	help := flag.Bool("help", false, "Print all possible flags")
 
@@ -66,46 +53,26 @@ func main() {
 
 	slog.SetDefault(logger)
 
-	if err := run(context.Background(), *port, *disableWhatsMyIP); err != nil {
+	if err := run(context.Background(), *port); err != nil {
 		slog.Error("server failed", "err", err)
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, port string, disableWhatsMyIP bool) error {
+func run(ctx context.Context, port string) error {
 	startTime := time.Now()
 	mux := http.NewServeMux()
 
 	// Create MCP server
-	mcpServer := mcp.NewServer("mcp-ripestat", version, disableWhatsMyIP)
+	mcpServer := mcp.NewServer("mcp-ripestat", version, false)
 
 	// Add MCP JSON-RPC endpoint
 	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
 		mcpHandler(w, r, mcpServer)
 	})
 
-	// Legacy REST API endpoints
-	mux.HandleFunc("/network-info", networkInfoHandler)
-	mux.HandleFunc("/as-overview", asOverviewHandler)
-	mux.HandleFunc("/announced-prefixes", announcedPrefixesHandler)
-	mux.HandleFunc("/routing-status", routingStatusHandler)
-	mux.HandleFunc("/routing-history", routingHistoryHandler)
-	mux.HandleFunc("/whois", whoisHandler)
-	mux.HandleFunc("/abuse-contact-finder", abuseContactFinderHandler)
-	mux.HandleFunc("/rpki-validation", rpkiValidationHandler)
-	mux.HandleFunc("/asn-neighbours", asnNeighboursHandler)
-	mux.HandleFunc("/looking-glass", lookingGlassHandler)
-
-	// Add whats-my-ip handler if not disabled
-	if !disableWhatsMyIP {
-		mux.HandleFunc("/whats-my-ip", whatsMyIPHandler)
-		slog.Info("whats-my-ip endpoint enabled")
-	} else {
-		slog.Info("whats-my-ip endpoint disabled")
-	}
-
 	mux.HandleFunc("/.well-known/mcp/manifest.json", func(w http.ResponseWriter, r *http.Request) {
-		manifestHandler(w, r, disableWhatsMyIP)
+		manifestHandler(w, r)
 	})
 
 	// Warmup endpoint to prevent cold starts
@@ -184,198 +151,10 @@ type Return struct {
 	Type string `json:"type"`
 }
 
-func manifestHandler(w http.ResponseWriter, r *http.Request, disableWhatsMyIP bool) {
+func manifestHandler(w http.ResponseWriter, r *http.Request) {
 	slog.Debug("received manifest request", "remote_addr", r.RemoteAddr)
 
-	functions := []Function{
-		{
-			Name:        "getNetworkInfo",
-			Description: "Get network information for an IP address or prefix.",
-			Parameters: []Parameter{
-				{
-					Name:        "resource",
-					Type:        "string",
-					Required:    true,
-					Description: "The IP address or prefix to query.",
-				},
-			},
-			Returns: Return{
-				Type: "object",
-			},
-		},
-		{
-			Name:        "getASOverview",
-			Description: "Get an overview of an Autonomous System (AS).",
-			Parameters: []Parameter{
-				{
-					Name:        "resource",
-					Type:        "string",
-					Required:    true,
-					Description: "The AS number to query.",
-				},
-			},
-			Returns: Return{
-				Type: "object",
-			},
-		},
-		{
-			Name:        "getAnnouncedPrefixes",
-			Description: "Get a list of prefixes announced by an Autonomous System (AS).",
-			Parameters: []Parameter{
-				{
-					Name:        "resource",
-					Type:        "string",
-					Required:    true,
-					Description: "The AS number to query.",
-				},
-			},
-			Returns: Return{
-				Type: "object",
-			},
-		},
-		{
-			Name:        "getRoutingStatus",
-			Description: "Get the routing status for an IP prefix.",
-			Parameters: []Parameter{
-				{
-					Name:        "resource",
-					Type:        "string",
-					Required:    true,
-					Description: "The IP prefix to query.",
-				},
-			},
-			Returns: Return{
-				Type: "object",
-			},
-		},
-		{
-			Name:        "getRoutingHistory",
-			Description: "Get routing history information for an IP address, prefix, or ASN.",
-			Parameters: []Parameter{
-				{
-					Name:        "resource",
-					Type:        "string",
-					Required:    true,
-					Description: "The IP address, prefix, or ASN to query for routing history.",
-				},
-			},
-			Returns: Return{
-				Type: "object",
-			},
-		},
-		{
-			Name:        "getWhois",
-			Description: "Get whois information for an IP address, prefix, or ASN.",
-			Parameters: []Parameter{
-				{
-					Name:        "resource",
-					Type:        "string",
-					Required:    true,
-					Description: "The IP address, prefix, or ASN to query.",
-				},
-			},
-			Returns: Return{
-				Type: "object",
-			},
-		},
-		{
-			Name:        "getAbuseContactFinder",
-			Description: "Get abuse contact information for an IP address or prefix.",
-			Parameters: []Parameter{
-				{
-					Name:        "resource",
-					Type:        "string",
-					Required:    true,
-					Description: "The IP address or prefix to query for abuse contacts.",
-				},
-			},
-			Returns: Return{
-				Type: "object",
-			},
-		},
-		{
-			Name:        "getRPKIValidation",
-			Description: "Get RPKI validation status for a resource (ASN) and prefix combination.",
-			Parameters: []Parameter{
-				{
-					Name:        "resource",
-					Type:        "string",
-					Required:    true,
-					Description: "The ASN to validate against the prefix.",
-				},
-				{
-					Name:        "prefix",
-					Type:        "string",
-					Required:    true,
-					Description: "The IP prefix to validate.",
-				},
-			},
-			Returns: Return{
-				Type: "object",
-			},
-		},
-		{
-			Name:        "getASNNeighbours",
-			Description: "Get ASN neighbours for an Autonomous System. Left neighbours are downstream providers, right neighbours are upstream providers.",
-			Parameters: []Parameter{
-				{
-					Name:        "resource",
-					Type:        "string",
-					Required:    true,
-					Description: "The AS number to query for neighbours.",
-				},
-				{
-					Name:        "lod",
-					Type:        "string",
-					Required:    false,
-					Description: "Level of detail: 0 (basic) or 1 (detailed with power, v4_peers, v6_peers). Default is 0.",
-				},
-				{
-					Name:        "query_time",
-					Type:        "string",
-					Required:    false,
-					Description: "Query time in ISO8601 format for historical data. If omitted, uses latest snapshot.",
-				},
-			},
-			Returns: Return{
-				Type: "object",
-			},
-		},
-		{
-			Name:        "getLookingGlass",
-			Description: "Get looking glass information for an IP prefix, showing BGP routing data from RIPE NCC's Route Reflection Collectors (RRCs).",
-			Parameters: []Parameter{
-				{
-					Name:        "resource",
-					Type:        "string",
-					Required:    true,
-					Description: "The IP prefix to query for looking glass information.",
-				},
-				{
-					Name:        "look_back_limit",
-					Type:        "string",
-					Required:    false,
-					Description: "Time limit in seconds to look back for BGP data. Maximum is 172800 seconds (48 hours). Default is 0.",
-				},
-			},
-			Returns: Return{
-				Type: "object",
-			},
-		},
-	}
-
-	// Add whats-my-ip function if not disabled
-	if !disableWhatsMyIP {
-		whatsMyIPFunction := Function{
-			Name:        "getWhatsMyIP",
-			Description: "Get the caller's public IP address. Respects X-Forwarded-For headers when behind a proxy.",
-			Parameters:  []Parameter{}, // No parameters required
-			Returns: Return{
-				Type: "object",
-			},
-		}
-		functions = append(functions, whatsMyIPFunction)
-	}
+	var functions []Function
 
 	manifest := Manifest{
 		Name:        "mcp-ripestat",
@@ -383,220 +162,6 @@ func manifestHandler(w http.ResponseWriter, r *http.Request, disableWhatsMyIP bo
 		Functions:   functions,
 	}
 	writeJSON(w, manifest, http.StatusOK)
-}
-
-func networkInfoHandler(w http.ResponseWriter, r *http.Request) {
-	handleRIPEstatRequest(w, r, "network-info", func(ctx context.Context, resource string) (interface{}, error) {
-		return networkinfo.GetNetworkInfo(ctx, resource)
-	})
-}
-
-func asOverviewHandler(w http.ResponseWriter, r *http.Request) {
-	handleRIPEstatRequest(w, r, "as-overview", func(ctx context.Context, resource string) (interface{}, error) {
-		return asoverview.GetASOverview(ctx, resource)
-	})
-}
-
-func announcedPrefixesHandler(w http.ResponseWriter, r *http.Request) {
-	handleRIPEstatRequest(w, r, "announced-prefixes", func(ctx context.Context, resource string) (interface{}, error) {
-		return announcedprefixes.GetAnnouncedPrefixes(ctx, resource)
-	})
-}
-
-func routingStatusHandler(w http.ResponseWriter, r *http.Request) {
-	handleRIPEstatRequest(w, r, "routing-status", func(ctx context.Context, resource string) (interface{}, error) {
-		return routingstatus.GetRoutingStatus(ctx, resource)
-	})
-}
-
-func routingHistoryHandler(w http.ResponseWriter, r *http.Request) {
-	handleRIPEstatRequest(w, r, "routing-history", func(ctx context.Context, resource string) (interface{}, error) {
-		return routinghistory.GetRoutingHistory(ctx, resource)
-	})
-}
-
-func whoisHandler(w http.ResponseWriter, r *http.Request) {
-	handleRIPEstatRequest(w, r, "whois", func(ctx context.Context, resource string) (interface{}, error) {
-		return whois.GetWhois(ctx, resource)
-	})
-}
-
-func abuseContactFinderHandler(w http.ResponseWriter, r *http.Request) {
-	handleRIPEstatRequest(w, r, "abuse-contact-finder", func(ctx context.Context, resource string) (interface{}, error) {
-		return abusecontactfinder.GetAbuseContactFinder(ctx, resource)
-	})
-}
-
-func rpkiValidationHandler(w http.ResponseWriter, r *http.Request) {
-	slog.Debug("received rpki-validation request", "remote_addr", r.RemoteAddr, "query", r.URL.RawQuery)
-
-	resource := r.URL.Query().Get("resource")
-	prefix := r.URL.Query().Get("prefix")
-
-	if resource == "" {
-		slog.Warn("missing resource parameter", "call_name", "rpki-validation")
-		writeJSONError(w, "missing resource parameter", http.StatusBadRequest)
-		return
-	}
-
-	if prefix == "" {
-		slog.Warn("missing prefix parameter", "call_name", "rpki-validation")
-		writeJSONError(w, "missing prefix parameter", http.StatusBadRequest)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	resp, err := rpkivalidation.GetRPKIValidation(ctx, resource, prefix)
-	if err != nil {
-		slog.Error("RIPEstat call failed", "call_name", "rpki-validation", "err", err)
-		writeJSONError(w, "failed to fetch rpki-validation", http.StatusBadGateway)
-		return
-	}
-
-	writeJSON(w, resp, http.StatusOK)
-}
-
-func asnNeighboursHandler(w http.ResponseWriter, r *http.Request) {
-	slog.Debug("received asn-neighbours request", "remote_addr", r.RemoteAddr, "query", r.URL.RawQuery)
-
-	resource := r.URL.Query().Get("resource")
-	lodStr := r.URL.Query().Get("lod")
-	queryTime := r.URL.Query().Get("query_time")
-
-	if resource == "" {
-		slog.Warn("missing resource parameter", "call_name", "asn-neighbours")
-		writeJSONError(w, "missing resource parameter", http.StatusBadRequest)
-		return
-	}
-
-	lod := 0 // default value
-	if lodStr != "" {
-		var err error
-		lod, err = strconv.Atoi(lodStr)
-		if err != nil || (lod != 0 && lod != 1) {
-			slog.Warn("invalid lod parameter", "call_name", "asn-neighbours", "lod", lodStr)
-			writeJSONError(w, "lod parameter must be 0 or 1", http.StatusBadRequest)
-			return
-		}
-	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	resp, err := asnneighbours.GetASNNeighbours(ctx, resource, lod, queryTime)
-	if err != nil {
-		slog.Error("RIPEstat call failed", "call_name", "asn-neighbours", "err", err)
-		writeJSONError(w, "failed to fetch asn-neighbours", http.StatusBadGateway)
-		return
-	}
-
-	writeJSON(w, resp, http.StatusOK)
-}
-
-func lookingGlassHandler(w http.ResponseWriter, r *http.Request) {
-	slog.Debug("received looking-glass request", "remote_addr", r.RemoteAddr, "query", r.URL.RawQuery)
-
-	resource := r.URL.Query().Get("resource")
-	lookBackLimitStr := r.URL.Query().Get("look_back_limit")
-
-	if resource == "" {
-		slog.Warn("missing resource parameter", "call_name", "looking-glass")
-		writeJSONError(w, "missing resource parameter", http.StatusBadRequest)
-		return
-	}
-
-	lookBackLimit := 0 // default value
-	if lookBackLimitStr != "" {
-		var err error
-		lookBackLimit, err = strconv.Atoi(lookBackLimitStr)
-		if err != nil {
-			slog.Warn("invalid look_back_limit parameter", "call_name", "looking-glass", "look_back_limit", lookBackLimitStr)
-			writeJSONError(w, "look_back_limit parameter must be a valid integer", http.StatusBadRequest)
-			return
-		}
-	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	resp, err := lookingglass.GetLookingGlass(ctx, resource, lookBackLimit)
-	if err != nil {
-		slog.Error("RIPEstat call failed", "call_name", "looking-glass", "err", err)
-		writeJSONError(w, "failed to fetch looking-glass", http.StatusBadGateway)
-		return
-	}
-
-	writeJSON(w, resp, http.StatusOK)
-}
-
-func whatsMyIPHandler(w http.ResponseWriter, r *http.Request) {
-	slog.Debug("received whats-my-ip request",
-		"remote_addr", r.RemoteAddr,
-		"x_forwarded_for", r.Header.Get("X-Forwarded-For"),
-		"x_real_ip", r.Header.Get("X-Real-IP"))
-
-	// Extract the real client IP from headers (for proxy scenarios)
-	clientIP := whatsmyip.ExtractClientIP(r)
-
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	// Check if we have proxy headers indicating we're behind a load balancer
-	hasProxyHeaders := r.Header.Get("X-Forwarded-For") != "" ||
-		r.Header.Get("X-Real-IP") != "" ||
-		r.Header.Get("CF-Connecting-IP") != ""
-
-	// Use the client IP if we detected proxy headers or if the extracted IP is different from RemoteAddr
-	var resp *whatsmyip.APIResponse
-	var err error
-
-	if hasProxyHeaders && clientIP != "" {
-		// We're behind a proxy/load balancer, use the extracted client IP
-		resp, err = whatsmyip.GetWhatsMyIPWithClientIP(ctx, clientIP)
-		slog.Debug("using extracted client IP from proxy headers",
-			"client_ip", clientIP,
-			"remote_addr", r.RemoteAddr,
-			"x_forwarded_for", r.Header.Get("X-Forwarded-For"))
-	} else {
-		// Direct connection or no proxy headers, use RIPEstat service
-		resp, err = whatsmyip.GetWhatsMyIP(ctx)
-		slog.Debug("using RIPEstat service for IP detection", "remote_addr", r.RemoteAddr)
-	}
-
-	if err != nil {
-		slog.Error("RIPEstat call failed", "call_name", "whats-my-ip", "err", err)
-		writeJSONError(w, "failed to fetch whats-my-ip", http.StatusBadGateway)
-		return
-	}
-
-	writeJSON(w, resp, http.StatusOK)
-}
-
-type ripeStatFunc func(ctx context.Context, resource string) (interface{}, error)
-
-func handleRIPEstatRequest(w http.ResponseWriter, r *http.Request, callName string, fn ripeStatFunc) {
-	slog.Debug("received request", "call_name", callName, "remote_addr", r.RemoteAddr, "query", r.URL.RawQuery)
-	resource := r.URL.Query().Get("resource")
-
-	if resource == "" {
-		slog.Warn("missing resource parameter", "call_name", callName)
-		writeJSONError(w, `missing resource parameter`, http.StatusBadRequest)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	resp, err := fn(ctx, resource)
-	if err != nil {
-		slog.Error("RIPEstat call failed", "call_name", callName, "err", err)
-		writeJSONError(w, fmt.Sprintf("failed to fetch %s", callName), http.StatusBadGateway)
-		return
-	}
-
-	writeJSON(w, resp, http.StatusOK)
 }
 
 // mcpHandler handles MCP JSON-RPC requests.


### PR DESCRIPTION
Removes all legacy REST API endpoints to keep the codebase compact and focused on MCP protocol.

## Summary
- Removed 11 legacy REST endpoints  
- Kept essential endpoints: /mcp, /status, /warmup, /.well-known/mcp/manifest.json
- All functionality available through MCP protocol
- Updated tests and documentation

## Breaking Change
This is a major version change that removes backward compatibility with REST API clients. All functionality remains available through the MCP protocol endpoint.