### PR TITLE
fix(docker): inject version during Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,8 @@ jobs:
           push: false
           tags: mcp-ripestat:latest
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
   release:
     name: Release
     runs-on: ubuntu-latest
@@ -185,6 +187,8 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.semantic.outputs.new_release_version }}
           tags: |-
             ghcr.io/taihen/mcp-ripestat:latest
             ghcr.io/taihen/mcp-ripestat:${{ steps.semantic.outputs.new_release_version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ COPY go.mod ./
 # There are no dependencies in go.mod, so we don't need to run `go mod download` here.
 # RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o /app/bin/mcp-ripestat ./cmd/mcp-ripestat
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.version=${VERSION}" -o /app/bin/mcp-ripestat ./cmd/mcp-ripestat
 FROM ghcr.io/taihen/base-image:v2025.06.26
 WORKDIR /app
 COPY --from=builder /app/bin/mcp-ripestat /app/mcp-ripestat


### PR DESCRIPTION
Fixes version reporting in deployed containers.

## Problem
The  endpoint on deployed instances was showing  instead of the actual release version.

## Root Cause
The Dockerfile was building the Go binary without injecting the version via ldflags, so it used the default fallback value of "dev".

## Solution
- Added VERSION build arg to Dockerfile with default value "dev"
- Updated Docker build command to use 
- Modified CI/CD pipeline to pass semantic-release version as build arg
- Updated test Docker build to use git version info

## Result
After deployment,  endpoint will correctly show the semantic-release version instead of "dev".