### PR TITLE
feat!: force major version release for API removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,8 @@ jobs:
         run: |
           # Get version from git tag or commit hash
           VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "Building with version: $VERSION"
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Building with version: ${VERSION}"
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Get version
+        id: version
+        run: |
+          # Get version from git tag or commit hash
+          VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Building with version: $VERSION"
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
@@ -132,7 +139,7 @@ jobs:
           tags: mcp-ripestat:latest
           platforms: linux/amd64,linux/arm64
           build-args: |
-            VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
+            VERSION=${{ steps.version.outputs.VERSION }}
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ JSON-RPC 2.0 transport. It provides two interfaces:
 - **Usage**: Compatible with Cursor IDE and other MCP clients
 - **Features**: Full MCP handshake, capability negotiation, tool calling
 
-### Legacy REST API (Removed in v2)
+### Legacy REST API (Removed in v2.0.0)
 
-> [!FAIL]
-> This API has been removed in v2. Use the MCP JSON-RPC endpoint instead.
+> [!FAIL] 
+> **BREAKING CHANGE**: All legacy REST API endpoints have been removed in v2.0.0. Use the MCP JSON-RPC endpoint instead.
 
-Legacy REST endpoints have been removed to keep the codebase compact and focused on the MCP protocol. All functionality previously available through REST endpoints is now accessible through the `/mcp` endpoint using the MCP protocol.
+This is a major breaking change. Legacy REST endpoints have been completely removed to keep the codebase compact and focused on the MCP protocol. All functionality previously available through REST endpoints is now accessible through the `/mcp` endpoint using the MCP protocol.
 
 ## MCP Client Configuration
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ JSON-RPC 2.0 transport. It provides two interfaces:
 
 ### Legacy REST API (Removed in v2.0.0)
 
-> [!FAIL] 
+> [!FAIL]
 > **BREAKING CHANGE**: All legacy REST API endpoints have been removed in v2.0.0. Use the MCP JSON-RPC endpoint instead.
 
 This is a major breaking change. Legacy REST endpoints have been completely removed to keep the codebase compact and focused on the MCP protocol. All functionality previously available through REST endpoints is now accessible through the `/mcp` endpoint using the MCP protocol.


### PR DESCRIPTION
Forces semantic-release to create v2.0.0 for the breaking changes made in previous commit.

## Problem
The previous commit with legacy REST API endpoint removal should have triggered v2.0.0 but semantic-release only created v1.16.1.

## Solution
This commit explicitly forces a major version bump with clear BREAKING CHANGE indicators to ensure semantic-release creates v2.0.0.

## Breaking Changes
- Removal of 11 legacy REST API endpoints
- Only MCP protocol and monitoring endpoints remain
- Clients using REST endpoints must migrate to MCP protocol

This ensures proper semantic versioning for the major breaking changes.