### PR TITLE
feat(whatsmyip): HTTP proxy header support for client IP detection

### DIFF
--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -32,7 +32,7 @@ The current implementation provides these RIPEstat API endpoints:
 
 **Utility:**
 
-- `getWhatsMyIP` - Caller's public IP address
+- `getWhatsMyIP` - Caller's public IP address (supports proxy headers for accurate client IP detection)
 
 ---
 
@@ -83,6 +83,7 @@ The current implementation provides these RIPEstat API endpoints:
 "What's my public IP address?"
 "Detect my current IP and show its network information"
 "Show me my IP and find its abuse contact"
+"Get my real client IP address (bypassing proxies/load balancers)"
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ For examples, investigation workflows, and usage patterns, see [PROMPTS](PROMPTS
 
 **Utility:**
 
+- What's My IP detection with proxy header support for accurate client IP identification behind load balancers, proxies, and CDNs
 - Health check and warmup endpoints for monitoring and deployment
 
 ## Architectural Rationale

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -38,4 +38,4 @@ implemented before Sprint 9 - depending on the needs of the project.
 | 21     | `sprint-21` | TBD     | BGP Updates                   | `bgp-updates`                | Planned   |
 | 22     | `sprint-22` | TBD     | Prefix Routing Consistency    | `prefix-routing-consistency` | Planned   |
 | 23     | `sprint-23` | v2.0.0  | Removal of REST API Endpoints | N/A                          | Completed |
-| 24     | `sprint-24` | TBD     | Support proxy headers         | N/A                          | Planned   |
+| 24     | `sprint-24` | TBD     | Support proxy headers         | N/A                          | Completed |

--- a/cmd/mcp-ripestat/main.go
+++ b/cmd/mcp-ripestat/main.go
@@ -185,6 +185,9 @@ func mcpHandler(w http.ResponseWriter, r *http.Request, server *mcp.Server) {
 	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
 	defer cancel()
 
+	// Store HTTP request in context for tools that need access to headers
+	ctx = mcp.WithHTTPRequest(ctx, r)
+
 	response, err := server.ProcessMessage(ctx, body)
 	if err != nil {
 		slog.Error("failed to process MCP message", "err", err)


### PR DESCRIPTION
## Summary
- Implements HTTP proxy header support for whats-my-ip endpoint
- Extracts real client IP from X-Forwarded-For, X-Real-IP, CF-Connecting-IP headers
- Maintains backward compatibility with fallback to standard behavior