### PR TITLE
feat(client): increase timeout to 30s with slow request warnings

### DIFF
--- a/internal/ripestat/config/config.go
+++ b/internal/ripestat/config/config.go
@@ -11,7 +11,7 @@ const (
 	DefaultBaseURL = "https://stat.ripe.net"
 
 	// DefaultTimeout is the default timeout for HTTP requests.
-	DefaultTimeout = 10 * time.Second
+	DefaultTimeout = 30 * time.Second
 
 	// DefaultRetryCount is the default number of retries for failed requests.
 	DefaultRetryCount = 3


### PR DESCRIPTION
## Summary
- Increased default HTTP client timeout from 10s to 30s to handle routing history requests
- Added warning logging for requests taking more than 10 seconds  
- Enhanced request timing tracking and error reporting