### PR TITLE
feat(rpki-history): implement RIPEstat RPKI history endpoint

### DIFF
--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -28,6 +28,7 @@ The current implementation provides these RIPEstat API endpoints:
 **Security & Compliance:**
 
 - `getRPKIValidation` - RPKI validation status for ASN/prefix pairs
+- `getRPKIHistory` - Historical RPKI validation status for IP prefixes
 - `getAbuseContactFinder` - Abuse contact information for resources
 
 **Geographic & Regional Analysis:**
@@ -79,6 +80,9 @@ The current implementation provides these RIPEstat API endpoints:
 "Check if AS15169 is authorized for 8.8.8.0/24"
 "Verify RPKI status of AS13335 and 104.16.0.0/13"
 "Is AS64496 valid for announcing 203.0.113.0/24?"
+"Show me the RPKI history for prefix 193.0.22.0/23"
+"When did 8.8.8.0/24 first appear in RPKI validation records?"
+"Track RPKI validation changes for 2001:7fb:ff00::/48 over time"
 ```
 
 ### Country & Geographic Queries

--- a/README.md
+++ b/README.md
@@ -145,13 +145,18 @@ JSON-RPC 2.0 transport. It provides two interfaces:
 > [!FAIL]
 > **BREAKING CHANGE**: All legacy REST API endpoints have been removed in v2.0.0. Use the MCP JSON-RPC endpoint instead.
 
-This is a major breaking change. Legacy REST endpoints have been completely removed to keep the codebase compact and focused on the MCP protocol. All functionality previously available through REST endpoints is now accessible through the `/mcp` endpoint using the MCP protocol.
+This is a major breaking change. Legacy REST endpoints have been completely
+removed to keep the codebase compact and focused on the MCP protocol. All
+functionality previously available through REST endpoints is now accessible
+through the `/mcp` endpoint using the MCP protocol.
 
 ## MCP Client Configuration
 
 To use this MCP server locally, simply copy and paste the
-[MCP client configuration](./mcp.json) into your MCP client (e.g. for Cursor,
-place it in `~/.cursor/mcp.json` on macOS/Linux).
+[MCP client configuration](./mcp.json) into your MCP client
+
+- **Cursor**: macOS/Linux: `~/.cursor/mcp.json`
+- **Claude Code**: `claude mcp add --transport http ripestat https://localhost:8080/mcp`
 
 ### Demo Server
 

--- a/SPRINTS.md
+++ b/SPRINTS.md
@@ -34,7 +34,7 @@ implemented before Sprint 9 - depending on the needs of the project.
 | 17     | `sprint-17` | v1.16.0 | Routing History               | `routing-history`            | Completed |
 | 18     | `sprint-18` | v2.3.0  | Country ASNs                  | `country-asns`               | Completed |
 | 19     | `sprint-19` | TBD     | Prefix Overview               | `prefix-overview`            | Planned   |
-| 20     | `sprint-20` | TBD     | RPKI History                  | `rpki-history`               | Planned   |
+| 20     | `sprint-20` | TBD     | RPKI History                  | `rpki-history`               | Completed |
 | 21     | `sprint-21` | TBD     | BGP Updates                   | `bgp-updates`                | Planned   |
 | 22     | `sprint-22` | TBD     | Prefix Routing Consistency    | `prefix-routing-consistency` | Planned   |
 | 23     | `sprint-23` | v2.0.0  | Removal of REST API Endpoints | N/A                          | Completed |

--- a/e2e/rpkihistory_test.go
+++ b/e2e/rpkihistory_test.go
@@ -74,8 +74,8 @@ func TestRPKIHistoryE2E(t *testing.T) {
 				if entry.Prefix == "" {
 					t.Error("Get() first entry has empty prefix")
 				}
-				if entry.Time == "" {
-					t.Error("Get() first entry has empty time")
+				if entry.Time.IsZero() {
+					t.Error("Get() first entry has zero time")
 				}
 				if entry.Family == 0 {
 					t.Error("Get() first entry has zero family")

--- a/e2e/rpkihistory_test.go
+++ b/e2e/rpkihistory_test.go
@@ -1,0 +1,91 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taihen/mcp-ripestat/internal/ripestat/client"
+	"github.com/taihen/mcp-ripestat/internal/ripestat/rpkihistory"
+)
+
+func TestRPKIHistoryE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test")
+	}
+
+	c := client.DefaultClient()
+	rpkiHistoryClient := rpkihistory.NewClient(c)
+
+	tests := []struct {
+		name     string
+		resource string
+		wantErr  bool
+	}{
+		{
+			name:     "RIPE NCC prefix",
+			resource: "193.0.22.0/23",
+			wantErr:  false,
+		},
+		{
+			name:     "IPv6 prefix",
+			resource: "2001:7fb:ff00::/48",
+			wantErr:  false,
+		},
+		{
+			name:     "Smaller prefix",
+			resource: "8.8.8.0/24",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := rpkiHistoryClient.Get(context.Background(), tt.resource)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Get() error = nil, wantErr %v", tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if result == nil {
+				t.Error("Get() result is nil, want non-nil")
+				return
+			}
+
+			if result.DataCallName != "rpki-history" {
+				t.Errorf("Get() result.DataCallName = %s, want rpki-history", result.DataCallName)
+			}
+
+			if result.Data.Timeseries == nil {
+				t.Error("Get() result.Data.Timeseries is nil, want non-nil")
+				return
+			}
+
+			// If timeseries has data, validate structure
+			if len(result.Data.Timeseries) > 0 {
+				entry := result.Data.Timeseries[0]
+				if entry.Prefix == "" {
+					t.Error("Get() first entry has empty prefix")
+				}
+				if entry.Time == "" {
+					t.Error("Get() first entry has empty time")
+				}
+				if entry.Family == 0 {
+					t.Error("Get() first entry has zero family")
+				}
+				if entry.MaxLength == 0 {
+					t.Error("Get() first entry has zero max_length")
+				}
+			} else {
+				t.Log("Get() result.Data.Timeseries is empty - this may be normal for some prefixes")
+			}
+		})
+	}
+}

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -295,6 +295,20 @@ func CreateToolsList() *ToolsListResult {
 			},
 		},
 		{
+			Name:        "getRPKIHistory",
+			Description: "Get RPKI history information for an IP prefix, showing the historical RPKI validation status.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"resource": map[string]interface{}{
+						"type":        "string",
+						"description": "The IP prefix to query for RPKI history.",
+					},
+				},
+				"required": []string{"resource"},
+			},
+		},
+		{
 			Name:        "getWhatsMyIP",
 			Description: "Get the caller's public IP address. Respects X-Forwarded-For headers when behind a proxy.",
 			InputSchema: map[string]interface{}{

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/taihen/mcp-ripestat/internal/ripestat/networkinfo"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/routinghistory"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/routingstatus"
+	"github.com/taihen/mcp-ripestat/internal/ripestat/rpkihistory"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/rpkivalidation"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/whatsmyip"
 	"github.com/taihen/mcp-ripestat/internal/ripestat/whois"
@@ -298,6 +299,8 @@ func (s *Server) executeToolCall(ctx context.Context, params *CallToolParams) (*
 		return s.callAbuseContactFinder(ctx, args)
 	case "getRPKIValidation":
 		return s.callRPKIValidation(ctx, args)
+	case "getRPKIHistory":
+		return s.callRPKIHistory(ctx, args)
 	case "getASNNeighbours":
 		return s.callASNNeighbours(ctx, args)
 	case "getLookingGlass":
@@ -426,6 +429,20 @@ func (s *Server) callRPKIValidation(ctx context.Context, args map[string]interfa
 	}
 
 	result, err := rpkivalidation.GetRPKIValidation(ctx, resource, prefix)
+	if err != nil {
+		return CreateToolResult(formatErrorMessage(err), true), nil
+	}
+
+	return CreateToolResultFromJSON(result), nil
+}
+
+func (s *Server) callRPKIHistory(ctx context.Context, args map[string]interface{}) (*ToolResult, error) {
+	resource, errResult := getRequiredStringParam(args, "resource", ErrResourceRequired)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	result, err := rpkihistory.GetRPKIHistory(ctx, resource)
 	if err != nil {
 		return CreateToolResult(formatErrorMessage(err), true), nil
 	}

--- a/internal/ripestat/rpkihistory/rpkihistory.go
+++ b/internal/ripestat/rpkihistory/rpkihistory.go
@@ -1,0 +1,57 @@
+// Package rpkihistory provides methods to interact with the RIPEStat RPKI
+// History endpoint.
+package rpkihistory
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/taihen/mcp-ripestat/internal/ripestat/client"
+	"github.com/taihen/mcp-ripestat/internal/ripestat/errors"
+)
+
+const (
+	// EndpointPath is the API path for the RPKI History endpoint.
+	EndpointPath = "/data/rpki-history/data.json"
+)
+
+// Client provides methods to interact with the RPKI History endpoint.
+type Client struct {
+	client *client.Client
+}
+
+// NewClient creates a new RPKI History client with the given HTTP client.
+func NewClient(c *client.Client) *Client {
+	if c == nil {
+		c = client.DefaultClient()
+	}
+	return &Client{client: c}
+}
+
+// DefaultClient returns a RPKI History client with the default HTTP client.
+func DefaultClient() *Client {
+	return NewClient(nil)
+}
+
+// Get retrieves RPKI History information for the given resource.
+func (c *Client) Get(ctx context.Context, resource string) (*Response, error) {
+	if resource == "" {
+		return nil, errors.ErrInvalidParameter.WithError(fmt.Errorf("resource parameter is required"))
+	}
+
+	params := url.Values{}
+	params.Set("resource", resource)
+
+	var response Response
+	if err := c.client.GetJSON(ctx, EndpointPath, params, &response); err != nil {
+		return nil, errors.ErrServerError.WithError(fmt.Errorf("failed to get RPKI history: %w", err))
+	}
+
+	return &response, nil
+}
+
+// GetRPKIHistory retrieves RPKI History information using the default client.
+func GetRPKIHistory(ctx context.Context, resource string) (*Response, error) {
+	return DefaultClient().Get(ctx, resource)
+}

--- a/internal/ripestat/rpkihistory/rpkihistory_exported_test.go
+++ b/internal/ripestat/rpkihistory/rpkihistory_exported_test.go
@@ -80,8 +80,8 @@ func TestGetRPKIHistory_Integration(t *testing.T) {
 				if entry.Prefix == "" {
 					t.Error("GetRPKIHistory() first entry has empty prefix")
 				}
-				if entry.Time == "" {
-					t.Error("GetRPKIHistory() first entry has empty time")
+				if entry.Time.IsZero() {
+					t.Error("GetRPKIHistory() first entry has zero time")
 				}
 				if entry.Family == 0 {
 					t.Error("GetRPKIHistory() first entry has zero family")

--- a/internal/ripestat/rpkihistory/rpkihistory_exported_test.go
+++ b/internal/ripestat/rpkihistory/rpkihistory_exported_test.go
@@ -1,0 +1,106 @@
+package rpkihistory_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/taihen/mcp-ripestat/internal/ripestat/rpkihistory"
+)
+
+func TestGetRPKIHistory_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tests := []struct {
+		name     string
+		resource string
+		wantErr  bool
+	}{
+		{
+			name:     "valid IPv4 prefix",
+			resource: "193.0.22.0/23",
+			wantErr:  false,
+		},
+		{
+			name:     "valid IPv6 prefix",
+			resource: "2001:7fb:ff00::/48",
+			wantErr:  false,
+		},
+		{
+			name:     "empty resource",
+			resource: "",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid resource",
+			resource: "invalid-resource",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			result, err := rpkihistory.GetRPKIHistory(ctx, tt.resource)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("GetRPKIHistory() error = nil, wantErr %v", tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("GetRPKIHistory() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if result == nil {
+				t.Error("GetRPKIHistory() result is nil")
+				return
+			}
+
+			if result.Data.Timeseries == nil {
+				t.Error("GetRPKIHistory() result.Data.Timeseries is nil")
+				return
+			}
+
+			// Basic validation of response structure
+			if result.DataCallName != "rpki-history" {
+				t.Errorf("GetRPKIHistory() DataCallName = %s, want rpki-history", result.DataCallName)
+			}
+
+			// If timeseries has data, validate structure
+			if len(result.Data.Timeseries) > 0 {
+				entry := result.Data.Timeseries[0]
+				if entry.Prefix == "" {
+					t.Error("GetRPKIHistory() first entry has empty prefix")
+				}
+				if entry.Time == "" {
+					t.Error("GetRPKIHistory() first entry has empty time")
+				}
+				if entry.Family == 0 {
+					t.Error("GetRPKIHistory() first entry has zero family")
+				}
+			}
+		})
+	}
+}
+
+func TestGetRPKIHistory_Timeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	defer cancel()
+
+	_, err := rpkihistory.GetRPKIHistory(ctx, "193.0.22.0/23")
+	if err == nil {
+		t.Error("GetRPKIHistory() expected timeout error, got nil")
+	}
+}

--- a/internal/ripestat/rpkihistory/rpkihistory_test.go
+++ b/internal/ripestat/rpkihistory/rpkihistory_test.go
@@ -1,0 +1,277 @@
+package rpkihistory
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/taihen/mcp-ripestat/internal/ripestat/client"
+)
+
+func TestClient_Get(t *testing.T) {
+	tests := []struct {
+		name         string
+		resource     string
+		mockResponse string
+		wantErr      bool
+		errContains  string
+	}{
+		{
+			name:     "valid prefix",
+			resource: "193.0.22.0/23",
+			mockResponse: `{
+				"messages": [],
+				"see_also": [],
+				"version": "0.1",
+				"data_call_name": "rpki-history",
+				"data_call_status": "development",
+				"cached": false,
+				"data": {
+					"timeseries": [
+						{
+							"prefix": "193.0.22.0/23",
+							"time": "2015-02-11T00:00:00Z",
+							"vrp_count": 1,
+							"count": 1,
+							"family": 4,
+							"max_length": 23
+						}
+					]
+				}
+			}`,
+			wantErr: false,
+		},
+		{
+			name:        "empty resource",
+			resource:    "",
+			wantErr:     true,
+			errContains: "resource parameter is required",
+		},
+		{
+			name:        "invalid resource",
+			resource:    "invalid-resource",
+			wantErr:     true,
+			errContains: "server error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.mockResponse != "" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(tt.mockResponse))
+				} else {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			}))
+			defer server.Close()
+
+			httpClient := client.New(server.URL, server.Client())
+			c := NewClient(httpClient)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			result, err := c.Get(ctx, tt.resource)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Get() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if tt.errContains != "" && !containsString(err.Error(), tt.errContains) {
+					t.Errorf("Get() error = %v, want error containing %s", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if result == nil {
+				t.Error("Get() result is nil")
+				return
+			}
+
+			if result.Data.Timeseries == nil {
+				t.Error("Get() result.Data.Timeseries is nil")
+				return
+			}
+
+			if len(result.Data.Timeseries) == 0 {
+				t.Error("Get() result.Data.Timeseries is empty")
+				return
+			}
+
+			entry := result.Data.Timeseries[0]
+			if entry.Prefix != "193.0.22.0/23" {
+				t.Errorf("Get() result.Data.Timeseries[0].Prefix = %s, want 193.0.22.0/23", entry.Prefix)
+			}
+			if entry.Family != 4 {
+				t.Errorf("Get() result.Data.Timeseries[0].Family = %d, want 4", entry.Family)
+			}
+		})
+	}
+}
+
+func TestClient_GetWithHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "Internal Server Error"}`))
+	}))
+	defer server.Close()
+
+	httpClient := client.New(server.URL, server.Client())
+	c := NewClient(httpClient)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := c.Get(ctx, "193.0.22.0/23")
+	if err == nil {
+		t.Error("Get() expected error for HTTP 500, got nil")
+	}
+}
+
+func TestClient_GetWithInvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"invalid": json}`))
+	}))
+	defer server.Close()
+
+	httpClient := client.New(server.URL, server.Client())
+	c := NewClient(httpClient)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := c.Get(ctx, "193.0.22.0/23")
+	if err == nil {
+		t.Error("Get() expected error for invalid JSON, got nil")
+	}
+}
+
+func TestClient_GetWithTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	httpClient := client.New(server.URL, &http.Client{Timeout: 100 * time.Millisecond})
+	c := NewClient(httpClient)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	_, err := c.Get(ctx, "193.0.22.0/23")
+	if err == nil {
+		t.Error("Get() expected timeout error, got nil")
+	}
+}
+
+func TestGetRPKIHistory(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		response := map[string]interface{}{
+			"messages":         []string{},
+			"see_also":         []string{},
+			"version":          "0.1",
+			"data_call_name":   "rpki-history",
+			"data_call_status": "development",
+			"cached":           false,
+			"data": map[string]interface{}{
+				"timeseries": []map[string]interface{}{
+					{
+						"prefix":     "193.0.22.0/23",
+						"time":       "2015-02-11T00:00:00Z",
+						"vrp_count":  1,
+						"count":      1,
+						"family":     4,
+						"max_length": 23,
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	httpClient := client.New(server.URL, server.Client())
+	c := NewClient(httpClient)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := c.Get(ctx, "193.0.22.0/23")
+	if err != nil {
+		t.Errorf("Get() error = %v, want nil", err)
+		return
+	}
+
+	if result == nil {
+		t.Error("Get() result is nil")
+		return
+	}
+
+	if len(result.Data.Timeseries) == 0 {
+		t.Error("Get() result.Data.Timeseries is empty")
+		return
+	}
+
+	entry := result.Data.Timeseries[0]
+	if entry.Prefix != "193.0.22.0/23" {
+		t.Errorf("Get() result.Data.Timeseries[0].Prefix = %s, want 193.0.22.0/23", entry.Prefix)
+	}
+}
+
+func TestNewClient(t *testing.T) {
+	httpClient := client.New("http://example.com", nil)
+	c := NewClient(httpClient)
+
+	if c == nil {
+		t.Error("NewClient() returned nil")
+		return
+	}
+	if c.client != httpClient {
+		t.Error("NewClient() did not set client correctly")
+	}
+}
+
+func TestNewClientWithNil(t *testing.T) {
+	c := NewClient(nil)
+	if c == nil {
+		t.Error("NewClient(nil) returned nil")
+		return
+	}
+	if c.client == nil {
+		t.Error("NewClient(nil) did not set default client")
+	}
+}
+
+func TestDefaultClient(t *testing.T) {
+	c := DefaultClient()
+	if c == nil {
+		t.Error("DefaultClient() returned nil")
+		return
+	}
+	if c.client == nil {
+		t.Error("DefaultClient() client is nil")
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(substr) == 0 || (len(s) >= len(substr) && s[len(s)-len(substr):] == substr) ||
+		(len(s) > len(substr) && s[:len(substr)] == substr) ||
+		(len(s) > len(substr) && strings.Contains(s, substr))
+}

--- a/internal/ripestat/rpkihistory/rpkihistory_test.go
+++ b/internal/ripestat/rpkihistory/rpkihistory_test.go
@@ -85,7 +85,7 @@ func TestClient_Get(t *testing.T) {
 					t.Errorf("Get() error = nil, wantErr %v", tt.wantErr)
 					return
 				}
-				if tt.errContains != "" && !containsString(err.Error(), tt.errContains) {
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
 					t.Errorf("Get() error = %v, want error containing %s", err, tt.errContains)
 				}
 				return
@@ -268,10 +268,4 @@ func TestDefaultClient(t *testing.T) {
 	if c.client == nil {
 		t.Error("DefaultClient() client is nil")
 	}
-}
-
-func containsString(s, substr string) bool {
-	return len(substr) == 0 || (len(s) >= len(substr) && s[len(s)-len(substr):] == substr) ||
-		(len(s) > len(substr) && s[:len(substr)] == substr) ||
-		(len(s) > len(substr) && strings.Contains(s, substr))
 }

--- a/internal/ripestat/rpkihistory/types.go
+++ b/internal/ripestat/rpkihistory/types.go
@@ -1,0 +1,26 @@
+package rpkihistory
+
+import (
+	"github.com/taihen/mcp-ripestat/internal/ripestat/types"
+)
+
+// Response represents the RIPEStat RPKI History response.
+type Response struct {
+	types.BaseResponse
+	Data Data `json:"data"`
+}
+
+// Data represents the data field in the RPKI History response.
+type Data struct {
+	Timeseries []TimeseriesEntry `json:"timeseries"`
+}
+
+// TimeseriesEntry represents a single entry in the RPKI History timeseries.
+type TimeseriesEntry struct {
+	Prefix    string `json:"prefix"`
+	Time      string `json:"time"`
+	VRPCount  int    `json:"vrp_count"`
+	Count     int    `json:"count"`
+	Family    int    `json:"family"`
+	MaxLength int    `json:"max_length"`
+}

--- a/internal/ripestat/rpkihistory/types.go
+++ b/internal/ripestat/rpkihistory/types.go
@@ -1,6 +1,8 @@
 package rpkihistory
 
 import (
+	"time"
+
 	"github.com/taihen/mcp-ripestat/internal/ripestat/types"
 )
 
@@ -17,10 +19,10 @@ type Data struct {
 
 // TimeseriesEntry represents a single entry in the RPKI History timeseries.
 type TimeseriesEntry struct {
-	Prefix    string `json:"prefix"`
-	Time      string `json:"time"`
-	VRPCount  int    `json:"vrp_count"`
-	Count     int    `json:"count"`
-	Family    int    `json:"family"`
-	MaxLength int    `json:"max_length"`
+	Prefix    string    `json:"prefix"`
+	Time      time.Time `json:"time"`
+	VRPCount  int       `json:"vrp_count"`
+	Count     int       `json:"count"`
+	Family    int       `json:"family"`
+	MaxLength int       `json:"max_length"`
 }


### PR DESCRIPTION
## Summary
- Implement RIPEstat RPKI History endpoint
- Add getRPKIHistory MCP tool for historical RPKI validation data
- Support timeseries data showing VRP count and validation status over time
- Follow established patterns for validation, error handling, and response structure

## Changes
- Add rpkihistory package with complete implementation
- Integrate with MCP protocol for tool access
- Update documentation and sprint tracking